### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
   - package-ecosystem: "composer" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"
     reviewers:
       - "wmde/funtech-core"
+    groups:
+      patch-updates:
+        update-types:
+          - patch


### PR DESCRIPTION
Also set the update interval to monthly because we have so few
dependencies and only dev dependencies
